### PR TITLE
Task ref

### DIFF
--- a/core/iam-api/src/main/java/io/thestencil/iam/api/UserActionsClient.java
+++ b/core/iam-api/src/main/java/io/thestencil/iam/api/UserActionsClient.java
@@ -151,6 +151,8 @@ public interface UserActionsClient {
   interface UserTask {
     String getId();
     String getStatus();
+    @Nullable
+    String getTaskRef();
     ZonedDateTime getCreated();
     @Nullable
     ZonedDateTime getUpdated();
@@ -176,6 +178,8 @@ public interface UserActionsClient {
 
     @Nullable
     String getTaskId();
+    @Nullable
+    String getTaskRef();
     @Nullable
     String getTaskStatus();
     @Nullable

--- a/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/CancelUserActionBuilderDefault.java
+++ b/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/CancelUserActionBuilderDefault.java
@@ -1,5 +1,7 @@
 package io.thestencil.iam.spi.integrations;
 
+import java.time.LocalDateTime;
+
 /*-
  * #%L
  * iam-api
@@ -84,6 +86,7 @@ public class CancelUserActionBuilderDefault extends BuilderTemplate implements C
   
   private static UserAction map(HttpResponse<?> resp, String fillUri, String reviewUri) {
     int code = resp.statusCode();
+    LocalDateTime now = LocalDateTime.now();
     if (code < 200 || code >= 300) {
       String error = "USER ACTIONS CANCEL: Can't create response, e = " + resp.statusCode() + " | " + resp.statusMessage() + " | " + resp.headers();
       LOGGER.error(error);
@@ -95,6 +98,8 @@ public class CancelUserActionBuilderDefault extends BuilderTemplate implements C
           .viewed(true)
           .formUri(fillUri)
           .formInProgress(false)
+          .created(now)
+          .updated(now)
           .build();
     }
     return ImmutableUserAction.builder()
@@ -103,9 +108,10 @@ public class CancelUserActionBuilderDefault extends BuilderTemplate implements C
         .reviewUri("")
         .messagesUri("")
         .formUri(fillUri)
-
         .viewed(true)
         .formInProgress(false)
+        .created(now)
+        .updated(now)
         .build();
   }
 }

--- a/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/UserActionBuilderDefault.java
+++ b/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/UserActionBuilderDefault.java
@@ -1,5 +1,7 @@
 package io.thestencil.iam.spi.integrations;
 
+import java.time.LocalDateTime;
+
 import javax.annotation.Nullable;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
@@ -176,6 +178,7 @@ public class UserActionBuilderDefault extends BuilderTemplate implements UserAct
     if (resp.statusCode() != 201) {
       String error = "USER ACTIONS: Can't create response, e = " + resp.statusCode() + " | " + resp.statusMessage() + " | " + resp.headers();
       LOGGER.error(error);
+      LocalDateTime now = LocalDateTime.now();
       return ImmutableUserAction.builder()
           .id("").name("").status("")
           .formId("")
@@ -183,6 +186,8 @@ public class UserActionBuilderDefault extends BuilderTemplate implements UserAct
           .formUri(fillUri)
           .viewed(true)
           .formInProgress(false)
+          .created(now)
+          .updated(now)
           .build();
     }
     final var body = resp.bodyAsJsonObject();

--- a/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/UserActionQueryDefault.java
+++ b/core/iam-api/src/main/java/io/thestencil/iam/spi/integrations/UserActionQueryDefault.java
@@ -223,6 +223,7 @@ public class UserActionQueryDefault extends BuilderTemplate implements UserActio
               .taskStatus(task.getStatus())
               .taskCreated(task.getCreated())
               .taskUpdated(task.getUpdated())
+              .taskRef(task.getTaskRef())
               .updated(lastUpdate)
               .addAllMessages(userMessages)
               .viewed(userMessages.isEmpty() || !unreadTasks.contains(action.getTaskId()))


### PR DESCRIPTION
Task object has taskRef, which is semantic identity for created task, it should be available to client and frontdesk user to have possibility to refer to specific created task.